### PR TITLE
feat(Wallet): add execution ordering via git-style branching

### DIFF
--- a/ruffsack/messages/admin.py
+++ b/ruffsack/messages/admin.py
@@ -8,6 +8,7 @@ from packaging.version import Version
 
 class ModifyBase(EIP712Message):
     _name_ = "Ruffsack Wallet"
+    parent: "bytes32"
     action: "uint256"  # type: ignore
     data: "bytes"
 
@@ -22,6 +23,7 @@ class ActionType(Flag):
 
     def __call__(
         self,
+        parent: bytes,
         *args,
         version: Version | None = None,
         address: AddressType | None = None,
@@ -46,6 +48,7 @@ class ActionType(Flag):
                 arg_types = ("address",)
 
         return Modify(  # type: ignore[call-arg]
+            parent=parent,
             action=self.value,
             data=abi_encode(arg_types, args),
         )

--- a/ruffsack/messages/execute.py
+++ b/ruffsack/messages/execute.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Self
 
+from ape.types import HexBytes
 from ape.utils import ManagerAccessMixin
 from eip712 import EIP712Message, EIP712Type
 
@@ -17,17 +18,24 @@ class Call(EIP712Type):
 class ExecuteBase(EIP712Message):
     _name_ = "Ruffsack Wallet"
 
+    parent: "bytes32"
     calls: list[Call] = []
 
 
 class Execute(ManagerAccessMixin):
-    def __init__(self, version: "Version", address: "AddressType", chain_id: int):
+    def __init__(
+        self,
+        parent: HexBytes,
+        version: "Version",
+        address: "AddressType",
+        chain_id: int,
+    ):
         class Execute(ExecuteBase):
             _verifyingContract_ = address
             _version_ = str(version)
             _chainId_ = chain_id
 
-        self.message = Execute()
+        self.message = Execute(parent=parent)
 
     def add_raw(self, target: "AddressType", value: int = 0, data: bytes = b"") -> Self:
         self.message.calls.append(Call(target=target, value=value, data=data))

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -7,6 +7,7 @@ def test_upgrade(
     new_impl = create_release()
 
     msg = ActionType.UPGRADE_IMPLEMENTATION(
+        sack.head(),
         new_impl.address,
         version=VERSION,
         address=sack.address,
@@ -32,11 +33,14 @@ def test_upgrade(
     ]
     assert sack.IMPLEMENTATION() == new_impl
 
+    assert sack.head() == msg._message_hash_
+
 
 def test_rotate_signers(
     accounts, chain, VERSION, THRESHOLD, sack, owners, approval_flow
 ):
     msg = ActionType.ROTATE_SIGNERS(
+        sack.head(),
         [accounts[len(owners)].address],
         [owners[0].address],
         sack.threshold(),
@@ -66,3 +70,5 @@ def test_rotate_signers(
     ]
     assert sack.signers(0) == accounts[1]
     assert sack.signers(len(owners) - 1) == accounts[len(owners)]
+
+    assert sack.head() == msg._message_hash_

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -40,6 +40,7 @@ def test_execute(
     accounts, chain, VERSION, THRESHOLD, owners, sack, approval_flow, calls
 ):
     txn = Execute(
+        parent=sack.head(),
         version=VERSION,
         address=sack.address,
         chain_id=chain.chain_id,
@@ -75,3 +76,4 @@ def test_execute(
         if total_calls > 0
         else []
     )
+    assert sack.head() == txn.message._message_hash_


### PR DESCRIPTION
### What I did

Prior to this PR, we did not have a way of ensuring  that `Modify`/`Execute` messages were executed in a specific order. This is important because there needs to be a way to ensure that we can enforce an off-chain ordering to the way that messages should be executed on-chain. The classical way of doing this would have been to use a "nonce" (self-incrementing integer value), allowing multiple messages to queue up at the same nonce height, allowing the ability to replace a badly-formatted transaction prior to attempting to commit it. However, this value also serves as an important representation of the transactions pending in the current queue (and their dependencies), and thus need to have a clearer correspondence to the intent of the proposer(s).

### How I did it

Here we have implemented a branching-style, hash-based mechanism for off-chain ordering, where the EIP712 message hash of the last message to be committed is referenced in the message itself. This enforces a natural ordering to how messages must be committed, and also gives a few nicer capabilities:
- "canonical-ness" of the message hash (vs. nonce) as the chief identifier of the transaction (increasing the security of referencing these values when signing on embedded devices e.g. HW wallets)
- the ability to definitively reference a specific decoded transaction using content-based routing (e.g. IPFS)
- a more intuitive representation for how transactions are displayed (using branches)

There is however a cost when "replacing" a transaction from the middle of a branch of transactions intended to be executed in sequence, as the later transactions will have to be "rebased" once the replacement is added, which could be somewhat annoying to signers. However, this sort of enforces revisiting the transaction sequence to ensure they are still valid, which could have a benefit of avoiding further invalid transactions being committed.

### How to verify it

The change is fairly simple, adding the method `head()` used to obtain the last committed transaciton. Module transactions (which bypass signature validation) do not use this feature.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
~~- [ ] Documentation is complete~~
