### PR TITLE
refactor(Factory): link proxy initcode at factory deployment

### DIFF
--- a/contracts/RuffsackFactory.vy
+++ b/contracts/RuffsackFactory.vy
@@ -5,7 +5,8 @@
 @author ApeWorX LTD.
 """
 
-PROXY_BLUEPRINT: public(immutable(address))
+PROXY_INITCODE: public(immutable(Bytes[1024]))
+
 
 # @dev The owner of the release registry that is allowed to add new releases.
 governance: public(address)
@@ -33,9 +34,9 @@ event NewRuffsack:
 
 
 @deploy
-def __init__(proxy_blueprint: address, governance: address):
-    PROXY_BLUEPRINT = proxy_blueprint
+def __init__(governance: address, proxy_initcode: Bytes[1024]):
     self.governance = governance
+    PROXY_INITCODE = proxy_initcode
 
 
 @external
@@ -60,13 +61,13 @@ def new(
     else:
         implementation = self.releases[version]
 
-    assert implementation != empty(address)
+    assert implementation != empty(address), "Invalid release"
 
     # NOTE: This does *not* depend on the version chosen by the user
     salt: bytes32 = keccak256(concat(abi_encode(signers, threshold), convert(tag, Bytes[64])))
 
-    new_sack: address = create_from_blueprint(
-        PROXY_BLUEPRINT,
+    new_sack: address = raw_create(
+        PROXY_INITCODE,
         implementation,
         signers,
         threshold,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,14 +26,10 @@ def governance(accounts):
 
 
 @pytest.fixture(scope="session")
-def PROXY_BLUEPRINT(project, deployer):
-    return deployer.declare(project.RuffsackProxy).contract_address
-
-
-@pytest.fixture(scope="session")
-def factory(project, deployer, governance, PROXY_BLUEPRINT):
+def factory(project, deployer, governance):
+    proxy_initcode = project.RuffsackProxy.contract_type.get_deployment_bytecode()
     return Factory(
-        deployer.deploy(project.RuffsackFactory, PROXY_BLUEPRINT, governance).address
+        deployer.deploy(project.RuffsackFactory, governance, proxy_initcode).address
     )
 
 


### PR DESCRIPTION
### What I did

Instead of having to deploy a blueprint, just link the `RuffsackProxy`'s initcode at deployment of the factory (since it should never change)

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
~~- [ ] Documentation is complete~~
