### PR TITLE
refactor(Contracts): set non-zero `.head` during initialize

### DIFF
--- a/sdk/py/caravan/factory.py
+++ b/sdk/py/caravan/factory.py
@@ -33,7 +33,7 @@ class Factory(ManagerAccessMixin):
         self._cached_releases: dict[Version, "ContractInstance"] = {
             # NOTE: This is the deterministic deployment address for v1 via CreateX
             Version("1"): PackageType.SINGLETON("1").at(
-                "0xf7AC37e8A31Da4D2Fbe7687118c142dd46e63517"
+                "0xB810c65972596d213DCdf0A73b27fa7be59Ef3E2"
             ),
         }
 

--- a/sdk/py/caravan/queue.py
+++ b/sdk/py/caravan/queue.py
@@ -107,7 +107,7 @@ class QueueManager(BaseModel):
 
     # QueueItem => list[QueueItem.hash]
     queue: dict[QueueItem, list[HexBytes]] = dict()
-    base: HexBytes = HexBytes("00" * 32)
+    base: HexBytes  # NOTE: Must always provide head!
 
     @model_validator(mode="after")
     def ensure_base(self) -> Self:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,7 @@ def new_van(deployer, factory, create_release):
 
         van = factory.new(owners, threshold, version=version, **txn_args)
         # NOTE: Make sure to use empty queue for testing
-        van.queue = QueueManager()
+        van.queue = QueueManager(base=van.head)
         return van
 
     return new_van

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1,6 +1,8 @@
 import ape
 import pytest
 
+from caravan.messages import ActionType
+
 
 def test_configuration(networks, van, VERSION, THRESHOLD, owners):
     assert set(van.signers) == set(o.address for o in owners)
@@ -19,6 +21,20 @@ def test_configuration(networks, van, VERSION, THRESHOLD, owners):
     assert address == van.address
     assert salt == b"\x00" * 32
     assert extensions == []
+
+    # NOTE: Initial head should be as if it did a ROTATE_SIGNERS modification
+    assert (
+        van.head
+        == ActionType.ROTATE_SIGNERS(
+            [o.address for o in owners],
+            [],
+            THRESHOLD,
+            address=address,
+            chain_id=chain_id,
+            version=version,
+            parent=b"\x00" * 32,
+        ).hash
+    )
 
 
 def test_initialize(singleton, van, THRESHOLD, owners):


### PR DESCRIPTION
### What I did

This PR sets `.head` during `Caravan.initialize` (as called via `Factory.new`) so that every deployment has a unique `.head` on different networks, adding a visual differentiator for signing purposes between deployment and the initial transaction made by the Wallet (which has been abused)

fixes: #23 

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete
